### PR TITLE
fix(npm): Fix for empty NPM tarballs generated by semantic-release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
+!*.config.js
 /*.js
 /types/*.js
+node_modules
 yarn.lock
-!babel.config.js

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/preset-env": "7.2.3",
     "@babel/preset-flow": "7.0.0",
     "@babel/preset-react": "7.0.0",
+    "@semantic-release/git": "7.0.7",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
     "babel-plugin-add-module-exports": "0.3.3",
@@ -44,18 +45,19 @@
     "semantic-release": "15.13.2"
   },
   "keywords": [
-    "gatsbyjs",
+    "exif",
     "gatsby",
     "gatsby-plugin",
+    "gatsbyjs",
     "photography",
-    "s3",
-    "exif"
+    "s3"
   ],
   "license": "MIT",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
     "lint": "eslint --format 'node_modules/eslint-friendly-formatter' --quiet --ext .js ./src",
-    "prepublish": "yarn build",
+    "prepublishOnly": "yarn build",
+    "semantic-release": "yarn build && semantic-release",
     "update": "ncu -ua && yarn -s",
     "watch": "yarn build -w"
   }

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/npm',
+    '@semantic-release/github',
+    [
+      '@semantic-release/git',
+      {
+        message:
+          // eslint-disable-next-line
+          'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+      },
+    ],
+  ],
+}


### PR DESCRIPTION
This is my second time running into to this; should have known better. Still — I'm [not the first][github] to have found this a little unintuitive -- it [appears][github 2] that not even `prepack` / `prepublishOnly` scripts get run during the `@semantic-release/npm` `publish` step (which is consistent with what I've observed in CI).

`¯\_(ツ)_/¯`

[github]: https://github.com/semantic-release/npm/issues/97
[github 2]: https://github.com/semantic-release/npm/issues/114#issuecomment-437451329