### PR TITLE
fix language for code hightlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ export const pageQuery = graphql`
 
 Add the dependency to your `package.json`:
 
-```console
+```shell
 $ yarn add gatsby-source-s3-image
 $ # Or:
 $ npm install --save gatsby-source-s3-image


### PR DESCRIPTION
fix warning:

```
warn unable to find prism language 'console' for highlighting. applying generic code block
```